### PR TITLE
feat: upgrade mac runner to macos 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "aceforeverd"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           path: deps/thirdparty-*.tar.gz
 
   thirdparty-darwin:
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       MAKEOPTS: -j3
 
@@ -109,7 +109,7 @@ jobs:
       - name: Xcode Select
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 12.1.1
+          xcode-version: 11.7
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.9


### PR DESCRIPTION
10.15 has deprecated: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/