### PR TITLE
revert(workflow): version for download/upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload Artifact
         if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.UPLOAD)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           path: deps/thirdparty-*.tar.gz
 
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload Artifact
         if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.UPLOAD)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: deps/thirdparty-*.tar.gz
 
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: generate signature
         working-directory: artifact


### PR DESCRIPTION
old container do not have required **GLIBC_2.27**